### PR TITLE
Fix wrong label placement

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/jquery": "^3.3.31",
     "@types/materialize-css": "^1.0.6",
     "@types/minimist": "^1.2.0",
-    "canvas": "2.5.0",
+    "canvas": "2.10.2",
     "minimist": "^1.2.3",
     "svg2img": "^0.6.1"
   }


### PR DESCRIPTION
I've been pulling my hair over this for the last 2 days when it finally struck me why some of the labels weren't being positioned correctly.
	
Given this use case image (A):

![pbn](https://user-images.githubusercontent.com/43894318/206443708-bd6fa39b-ae08-46a1-b84a-f98d7fc2f4db.png)

When determining the holes for the polygon that gets plugged into polylabel, the facet for the blue color (B) is only checking its neighbouring facets that fall inside it. As the yellow facet is completely shielded by the red facet, the yellow facet is not included as it is not considered a neighbour. The result is an incorrect mask and therefore incorrect label placement (C).

This PR checks all facets that fall inside the current facet and strips all facets that fall inside another to prevent holes within holes (the oddeven rule would otherwise revert this example back to C). This results in a correct mask and label placement (D).

Note that this could probably be optimized and is not thoroughly tested though it seems to fix all of my test images.